### PR TITLE
Fixed a bug in 'scriptPath'

### DIFF
--- a/chalkboard/chalkboard.js
+++ b/chalkboard/chalkboard.js
@@ -12,18 +12,22 @@
 ******************************************************************/
 
 var RevealChalkboard = window.RevealChalkboard || (function(){
+var RevealChalkboard = window.RevealChalkboard || (function(){
 	var path = scriptPath();
 	function scriptPath() {
 		// obtain plugin path from the script element
-		var path;
+		var src;
 		if (document.currentScript) {
-			path = document.currentScript.src.slice(0, -13);
+			src = document.currentScript.src;
 		} else {
 			var sel = document.querySelector('script[src$="/chalkboard.js"]')
 			if (sel) {
-				path = sel.src.slice(0, -13);
+				src = sel.src;
 			}
 		}
+
+		var path = typeof src === undefined ? src
+			: src.slice(0, src.lastIndexOf("/") + 1);
 //console.log("Path: " + path);
 		return path;
 	}


### PR DESCRIPTION
'scriptPath' used a magic number to transform 'foo/bar/chalkboard.js' into 'foo/bar/'. This was very fragile and broke e.g. when the script was loaded with a GET parameter 'foo/bar/chalkboard.js?v=2'. The new version simply removes the substring after last '/'.