### PR TITLE
Update README.md

### DIFF
--- a/chalkboard/README.md
+++ b/chalkboard/README.md
@@ -100,13 +100,13 @@ Reveal.initialize({
 	// ...
 	chalkboard: { 
 		src: null,
-		readOnly: undefined; 
+		readOnly: undefined, 
 		toggleChalkboardButton: { left: "30px", bottom: "30px", top: "auto", right: "auto" },
 		toggleNotesButton: { left: "30px", bottom: "30px", top: "auto", right: "auto" },
 		transition: 800,
 		theme: "chalkboard",
 		// configuration options for notes canvas and chalkboard
-		color: [ 'rgba(0,0,255,1)', 'rgba(255,255,255,0.5)' ]
+		color: [ 'rgba(0,0,255,1)', 'rgba(255,255,255,0.5)' ],
 		background: [ 'rgba(127,127,127,.1)' , 'reveal.js-plugins/chalkboard/img/blackboard.png' ],
 		pen:  [ 'url(reveal.js-plugins/chalkboard/img/boardmarker.png), auto', 'url(reveal.js-plugins/chalkboard/img/chalk.png), auto' ],
 	},


### PR DESCRIPTION
I'm enjoying the chalkboard plugin and found a subtle typo at the end of configuration (All of the configurations are ... ) in README.md.

As I changed, I think arguments should be separated by commas （','）, not by semicolons （';'）. 
It may is not essential but if I copy the configuration and paste it in my reveal.js HTML file, it brings me to a failure of the read files at least my environment (chrome Version 56.0.2924.87 (64-bit)). 

Thank you.