### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "reveal.js-menu"]
 	path = menu
-	url = git://github.com/denehyg/reveal.js-menu.git
+	url = https://github.com/denehyg/reveal.js-menu.git


### PR DESCRIPTION
Modified reference to the menu submodule with "https://" instead of "git:" to error  "page build failed: Invalid submodule" when publishing via github.pages 

(see: https://help.github.com/articles/page-build-failed-invalid-submodule/)