### PR TITLE
Add new parameters externalPlayerCSS and onlyIfLocalAudio

### DIFF
--- a/audio-slideshow/README.md
+++ b/audio-slideshow/README.md
@@ -48,10 +48,14 @@ Reveal.initialize({
 		defaultDuration: 5,	// default duration in seconds if no audio is available 
 		playerOpacity: 0.05,	// opacity value of audio player if unfocused
 		startAtFragment: false, // when moving to a slide, start at the current fragment or at the start of the slide
+		onlyIfLocalAudio = false, // only show audio player if local audio file exists
+		externalPlayerCSS = false, // use external CSS for class 'audio-controls' to style audio player
 	},
 	// ...
 });
 ```
+
+The audio player comes with a fixed default CSS style.  By setting the parameter ```externalPlayerCSS``` to ```true```, the player's CSS class ```audio-controls``` does not receive any attributes but can be defined externally.
 
 You can configure keyboard shortcuts for the ```slideshow-recorder.js``` plugin by configuring the ```keyboard``` option in the reveal.js initialization options. 
 
@@ -125,6 +129,8 @@ After stopping the recorder, you can use the audio controls to check your record
 #### Slides without audio
 
 If no audio file and no text is provided for a slide or fragment, the slide advances after the duration specified by the ```defaultDuration``` parameter.
+
+If the ```onlyIfLocalAudio``` parameter is set to ```true```, no audio player is shown if no local audio file is present.
 
 #### Options for automatically advancing to next slide
 

--- a/audio-slideshow/audio-slideshow.js
+++ b/audio-slideshow/audio-slideshow.js
@@ -28,6 +28,8 @@ var RevealAudioSlideshow = window.RevealAudioSlideshow || (function(){
 	var autoplay = false; // automatically start slideshow
 	var playerOpacity = .05; // opacity when the mouse is far from to the audioplayer
 	var startAtFragment = false; // when moving to a slide, start at the current fragment or at the start of the slide
+	var onlyIfLocalAudio = false; // only show audio player if local audio file exists
+	var externalPlayerCSS = false; // use external CSS for class 'audio-controls' to style audio player
 	// ------------------
 
 	var silence;
@@ -153,6 +155,8 @@ var RevealAudioSlideshow = window.RevealAudioSlideshow || (function(){
 			if ( config.advance ) advance = config.advance;
 			if ( config.autoplay ) autoplay = config.autoplay;
 			if ( config.playerOpacity ) playerOpacity = config.playerOpacity;
+			if ( config.onlyIfLocalAudio ) onlyIfLocalAudio = config.onlyIfLocalAudio;
+			if ( config.externalPlayerCSS ) externalPlayerCSS = config.externalPlayerCSS;
 		}
 
 		if ( 'ontouchstart' in window || navigator.msMaxTouchPoints ) {
@@ -175,7 +179,9 @@ var RevealAudioSlideshow = window.RevealAudioSlideshow || (function(){
 
 		var divElement =  document.createElement( 'div' );
 		divElement.className = "audio-controls";
-		divElement.setAttribute( 'style', "width: 50%; height:75px; position: fixed; left: 25%; bottom: 4px;z-index: 33;" );
+		if ( !externalPlayerCSS ) {
+			divElement.setAttribute( 'style', "width: 50%; height:75px; position: fixed; left: 25%; bottom: 4px;z-index: 33;" );
+		}
 		document.querySelector( ".reveal" ).appendChild( divElement );
 
 		// create audio players for all slides
@@ -426,8 +432,10 @@ var RevealAudioSlideshow = window.RevealAudioSlideshow || (function(){
 				audioElement.insertBefore(audioSource, audioElement.firstChild);
 				setupFallbackAudio( audioElement, text, videoElement );
 			}
-		}	
-		container.appendChild( audioElement );
+		}
+		if ( audioFile != null || !onlyIfLocalAudio ) {
+			container.appendChild( audioElement );
+		}
 	}
 
 


### PR DESCRIPTION
With externalPlayerCSS, no fixed CSS attributes are used.
With onlyIfLocalAudio, no audio player is shown if no local audio
file exists.

README.md mentions both options.