### PR TITLE
Do not start audio player in speaker view window

### DIFF
--- a/audio-slideshow/audio-slideshow.js
+++ b/audio-slideshow/audio-slideshow.js
@@ -89,6 +89,7 @@ var RevealAudioSlideshow = window.RevealAudioSlideshow || (function(){
 	} );
 
 	function selectAudio( previousAudio ) {
+		if ( !!window.location.search.match( /receiver/gi ) ) return;
 		if ( currentAudio ) {
 			currentAudio.pause();
 			currentAudio.style.display = "none";


### PR DESCRIPTION
Test whether window is part of speaker view. If so, do not start audio. Closes #39.
The code is copied from `isSpeakerNotes()` in reveal.js, which is currently not exported. I opened a [PR for reveal.js](https://github.com/hakimel/reveal.js/pull/2029) to export that function. If that gets accepted, `Reveal.isSpeakerNotes()` should be called here.