### PR TITLE
a sample package.json for publishing the chalkboard plugin under npm

### DIFF
--- a/chalkboard/package.json
+++ b/chalkboard/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "reveal.js-chalkboard",
+  "version": "1.0.0",
+  "description": "Add a blackboard to your reveal.js presentations",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rajgoel/reveal.js-plugins.git"
+  },
+  "keywords": [
+    "reveal",
+    "chalkboard",
+    "blackboard"
+  ],
+  "author": "Asvin Goel",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/rajgoel/reveal.js-plugins.git/issues"
+  },
+  "homepage": "https://github.com/rajgoel/reveal.js-plugins/blob/master/chalkboard/README.md",
+  "dependencies": {
+    "npm": "^5.8.0"
+  }
+}


### PR DESCRIPTION
A possible implementation for #46 : a sample and simple `package.json` is all that is needed

I found other reveal/js plugins already available under npm of course, I have used the same naming scheme

Also I made up the first version number, as I had to start from something

*****

steps for publishing:

* register at npmjs.com (or just run npm adduser)
* npm login
* npm publish

step for installing

* cd wherever/you/need/to
* npm install reveal.js-chalkboard

****

Note that I have tested all this with my own login  (parmentelat) at `npmjs.com` that I just created for that purpose

I am not familiar enough with npm to foresee whether this is going to be in the way for you to publish under the same name, let me know if you need me to clean stuff up 