### PR TITLE
Workaround for Chrome forcing passive event handling by default

### DIFF
--- a/chalkboard/chalkboard.js
+++ b/chalkboard/chalkboard.js
@@ -31,6 +31,15 @@ var RevealChalkboard = window.RevealChalkboard || (function(){
 		return path;
 }
 
+
+/* Feature detection for passive event handling*/
+var passiveSupported = false;
+
+try {
+  window.addEventListener("test", null, Object.defineProperty({}, "passive", { get: function() { passiveSupported = true; } }));
+} catch(err) {}
+
+
 /*****************************************************************
 ** Configuration
 ******************************************************************/
@@ -873,7 +882,7 @@ console.log( 'Create printout for slide ' + storage[1].data[i].slide.h + "." + s
 */
 			touchTimeout = setTimeout( showSponge, 500, mouseX, mouseY );
 		}	
-	}, false);
+	}, passiveSupported ? {passive: false} : false);
 
 	document.addEventListener('touchmove', function(evt) {
 		clearTimeout( touchTimeout );


### PR DESCRIPTION
In Chrome and Firefox, touch event listeners are forced to be passive by default.  As a consequence, the initial touch point registers at the correct place but at a later time, once the touch input has moved a relatively far distance away.  The second event to register is then this farther point, leading to ignoring all interim movement.  After the second registered point, everything works as expected.

This commit adds `{passive: false}` to the `touchstart` event handler following: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Improving_scrolling_performance_with_passive_listeners

This fixes touch behavior on Chrome, but does not seem to fix the same issue on Firefox.  For browsers that do not support the `passive` option, it does not pass this option.