### PR TITLE
Add config option defaultAudios

### DIFF
--- a/audio-slideshow/README.md
+++ b/audio-slideshow/README.md
@@ -47,6 +47,7 @@ Reveal.initialize({
 		advance: 0, 		// advance to next slide after given time in milliseconds after audio has played, use negative value to not advance 
 		autoplay: false,	// automatically start slideshow
 		defaultDuration: 5,	// default duration in seconds if no audio is available 
+		defaultAudios: true,	// try to play audios with names such as audio/1.2.ogg
 		playerOpacity: 0.05,	// opacity value of audio player if unfocused
 		playerStyle: 'position: fixed; bottom: 4px; left: 25%; width: 50%; height:75px; z-index: 33;', // style used for container of audio controls 
 		startAtFragment: false, // when moving to a slide, start at the current fragment or at the start of the slide
@@ -85,6 +86,8 @@ For each slide or fragment you can explicitly specify a file to be played when t
 ```
 
 If no audio file is explicitly specified, the plugin automatically determines the name of the audio file using the given ```prefix```, the slide (or fragment) indices, and the ```suffix```, e.g. in the above code the slideshow will play the file ```audio/1.2.ogg```  before the fragment is shown (assuming that ```prefix``` is ```"audio/"```, ```suffix``` is ```".ogg"``` , ```Reveal.getIndices().h``` is ```"1"``` and ```Reveal.getIndices().v``` is ```"2"```).
+
+If you just want to play audio when file names are explicitly set with ```data-audio-src```, configure ```defaultAudios``` to ```false```.
 
 ### Text-to-speech
 

--- a/audio-slideshow/audio-slideshow.js
+++ b/audio-slideshow/audio-slideshow.js
@@ -24,6 +24,7 @@ var RevealAudioSlideshow = window.RevealAudioSlideshow || (function(){
 	var defaultNotes = false; // use slide notes as default for the text to speech converter
 	var defaultText = false; // use slide text as default for the text to speech converter
 	var defaultDuration = 5; // value in seconds
+	var defaultAudios = true; // try to obtain audio for slide and fragment numbers
 	var advance = 0; // advance to next slide after given time in milliseconds after audio has played, use negative value to not advance 
 	var autoplay = false; // automatically start slideshow
 	var playerOpacity = .05; // opacity when the mouse is far from to the audioplayer
@@ -151,6 +152,7 @@ var RevealAudioSlideshow = window.RevealAudioSlideshow || (function(){
 			if ( config.defaultNotes != null ) defaultNotes = config.defaultNotes;
 			if ( config.defaultText != null ) defaultText = config.defaultText;
 			if ( config.defaultDuration != null ) defaultDuration = config.defaultDuration;
+			if ( config.defaultAudios != null ) defaultAudios = config.defaultAudios;
 			if ( config.advance != null ) advance = config.advance;
 			if ( config.autoplay != null ) autoplay = config.autoplay;
 			if ( config.playerOpacity != null  ) playerOpacity = config.playerOpacity;
@@ -402,7 +404,7 @@ var RevealAudioSlideshow = window.RevealAudioSlideshow || (function(){
 				audioElement.insertBefore(audioSource, audioElement.firstChild);
 			} );
 		}
-		else {
+		else if ( defaultAudios ) {
 			var audioExists = false;
 			try {
 				// check if audio file exists 


### PR DESCRIPTION
Set this to false to prevent the generation of audio file names such
as audio/1.2.ogg.  For presentations where audio is used selectively,
this prevents lots of 404 errors for non-existing audio files.