### PR TITLE
Make Chalkboard plugin work with reveal.js 4.0

### DIFF
--- a/chalkboard/chalkboard.js
+++ b/chalkboard/chalkboard.js
@@ -3,7 +3,7 @@
 **
 ** A plugin for reveal.js adding a chalkboard.
 **
-** Version: 0.9
+** Version: 0.9.1
 **
 ** License: MIT license (see LICENSE.md)
 **
@@ -211,7 +211,8 @@ try {
 		if ( id == "0" ) {
 			container.style.background = 'rgba(0,0,0,0)';
 			container.style.zIndex = "24";
-			container.classList.add( 'visible' )
+			container.style.opacity = 1;
+			container.style.visibility = 'visible';
 			container.style.pointerEvents = "none";
 
 			var slides = document.querySelector(".slides");
@@ -226,6 +227,8 @@ try {
 		else {
 			container.style.background = 'url("' + background[id] + '") repeat';
 			container.style.zIndex = "26";
+			container.style.opacity = 0;
+			container.style.visibility = 'hidden';
 		}
 
 		var sponge = document.createElement( 'img' );
@@ -379,7 +382,8 @@ try {
 
 	function createPrintout( ) {
 //console.log( 'Create printout for ' + storage[1].data.length + " slides");
-		drawingCanvas[0].container.classList.remove( 'visible' ); // do not print notes canvas
+		drawingCanvas[0].container.style.opacity = 0; // do not print notes canvas
+		drawingCanvas[0].container.style.visibility = 'hidden';
 		var nextSlide = [];
 		for (var i = 0; i < storage[1].data.length; i++) {
 			var slide = Reveal.getSlide( storage[1].data[i].slide.h, storage[1].data[i].slide.v );
@@ -545,7 +549,8 @@ console.log( 'Create printout for slide ' + storage[1].data[i].slide.h + "." + s
 		touchTimeout = null;
 		drawingCanvas[0].sponge.style.visibility = "hidden"; // make sure that the sponge from touch events is hidden
 		drawingCanvas[1].sponge.style.visibility = "hidden"; // make sure that the sponge from touch events is hidden
-		drawingCanvas[1].container.classList.add( 'visible' );
+		drawingCanvas[1].container.style.opacity = 1;
+		drawingCanvas[1].container.style.visibility = 'visible';
 		mode = 1;
 		// broadcast
 		var message = new CustomEvent('send');
@@ -562,7 +567,8 @@ console.log( 'Create printout for slide ' + storage[1].data[i].slide.h + "." + s
 		touchTimeout = null;
 		drawingCanvas[0].sponge.style.visibility = "hidden"; // make sure that the sponge from touch events is hidden
 		drawingCanvas[1].sponge.style.visibility = "hidden"; // make sure that the sponge from touch events is hidden
-		drawingCanvas[1].container.classList.remove( 'visible' );
+		drawingCanvas[1].container.style.opacity = 0;
+		drawingCanvas[1].container.style.visibility = 'hidden';
 		xLast = null;
 		yLast = null;
 		event = null;


### PR DESCRIPTION
The chalkboard was permanently visible and covered the presentation when loading the plugin with reveal.js 4.0. This happened because the `visible` class that the plugin relied on no longer exists in the reveal.js CSS.

The quickest fix I could think of was to manually set the `visibility` and `opacity` to show/hide the drawing overlays instead. This is my first time setting up the plugin so please do test to make sure I didn't break anything without noticing :)

Fixes #80 