### PR TITLE
Check currentAudio before pausing

### DIFF
--- a/audio-slideshow/audio-slideshow.js
+++ b/audio-slideshow/audio-slideshow.js
@@ -71,7 +71,7 @@ var RevealAudioSlideshow = window.RevealAudioSlideshow || (function(){
 
 	Reveal.addEventListener( 'paused', function( event ) {
 		if ( timer ) { clearTimeout( timer ); timer = null; }
-		currentAudio.pause();
+		if ( currentAudio ) { currentAudio.pause(); }
 	} );
 
 	Reveal.addEventListener( 'resumed', function( event ) {
@@ -80,7 +80,7 @@ var RevealAudioSlideshow = window.RevealAudioSlideshow || (function(){
 
 	Reveal.addEventListener( 'overviewshown', function( event ) {
 		if ( timer ) { clearTimeout( timer ); timer = null; }
-		currentAudio.pause();
+		if ( currentAudio ) { currentAudio.pause(); }
 		document.querySelector(".audio-controls").style.visibility = "hidden";
 	} );
 


### PR DESCRIPTION
In my presentations, not all slides contain audio. If the overview is shown (with `o`) on a slide without audio, `currentAudio`is `null`. Test this. 

For symmetry, I also added the test for `paused`. Maybe not necessary.