### PR TITLE
Handling SVG files generated by python matplotlib

### DIFF
--- a/mathsvg/math.js
+++ b/mathsvg/math.js
@@ -126,11 +126,15 @@ var RevealMathSVG = window.RevealMathSVG || (function(){
 		var y =  +svgdest.getAttribute( 'y' );
 		if ( svgdest.hasAttribute( 'dy' ) ) x = x + svgdest.getAttribute( 'dy' );
 
+		var transform_value = "";
+		if ( svgdest.hasAttribute( 'transform' ) ) transform_value += svgdest.getAttribute( 'transform' );
+
 		var x0 = x;
 		var y0 = y;
 		var x1 = -svgmathinfo.width * 0.5;
 		var y1 = svgmathinfo.height * 0.25;
-		gnodes.setAttribute( 'transform', 'translate('+x0+' '+y0+') scale('+scale+') translate('+x1+' '+y1+') matrix(1 0 0 -1 0 0)' );
+		transform_value += 'translate('+x0+' '+y0+') scale('+scale+') translate('+x1+' '+y1+') matrix(1 0 0 -1 0 0)'
+		gnodes.setAttribute( 'transform',  transform_value);
 		if ( svgdest.hasAttribute( 'fill' ) ) gnodes.setAttribute( 'fill', svgdest.getAttribute( 'fill' ) );
 		if ( svgdest.hasAttribute( 'stroke' ) ) gnodes.setAttribute( 'stroke', svgdest.getAttribute( 'stroke' ) );
 

--- a/mathsvg/math.js
+++ b/mathsvg/math.js
@@ -1,13 +1,13 @@
 /*****************************************************************
 ** Author: Asvin Goel, goel@telematique.eu
 **
-** An extension of the math.js plugin for reveal.js enabling 
+** An extension of the math.js plugin for reveal.js enabling
 ** rendering of math equations inside SVG graphics.
 **
 ** Credits:
-** - Hakim El Hattab for math.js 
+** - Hakim El Hattab for math.js
 **   MIT licensed
-** - Jason M. Sachs for svg_mathjax.js  
+** - Jason M. Sachs for svg_mathjax.js
 **   Source: https://bitbucket.org/jason_s/svg_mathjax
 **   License: http://www.apache.org/licenses/LICENSE-2.0
 ******************************************************************/
@@ -73,8 +73,8 @@ var RevealMathSVG = window.RevealMathSVG || (function(){
 	}
 
 	// apply a function to elements of an array x
-	function forEach( x, f ) { 
-		var n = x.length; for ( var i = 0; i < n; ++i ) { f( x[i] ); } 
+	function forEach( x, f ) {
+		var n = x.length; for ( var i = 0; i < n; ++i ) { f( x[i] ); }
 	}
 
 	function cleanup( mathbucket ) {
@@ -82,15 +82,44 @@ var RevealMathSVG = window.RevealMathSVG || (function(){
 		mathbucket.parentNode.removeChild( mathbucket );
 	}
 
+	function getFirstNumber(str) {
+		var regex = /[+-]?\d+(?:\.\d+)?/g;
+		var match = regex.exec(str);
+		var number;
+		try {
+			number = match[0];
+		} catch (TypeError) {
+			number = null;
+		}
+		return number;
+	}
+
+	function getFontSize(tag) {
+		var fontsize = getFirstNumber(tag.getAttribute( 'font-size' ));
+
+		if (fontsize === null) {
+			styles = tag.getAttribute('style').split(";");
+			for (style_value of styles) {
+				var key_value = style_value.split(":");
+				if (key_value[0] === "font-size") {
+					fontsize = getFirstNumber(key_value[1]);
+					break;
+				}
+			}
+		}
+
+		return fontsize;
+	}
+
 	function replaceText( svgdest, mathjaxdiv, textcontainer ) {
 		var svgmath = mathjaxdiv.getElementsByClassName( 'MathJax_SVG' )[0].getElementsByTagName( 'svg' )[0];
 		var svgmathinfo = {
-		  width: svgmath.viewBox.baseVal.width, 
+		  width: svgmath.viewBox.baseVal.width,
 		  height: svgmath.viewBox.baseVal.height
 		};
 		// get graphics nodes
 		var gnodes = svgmath.getElementsByTagName( 'g' )[0].cloneNode( true );
-		var fontsize = svgdest.getAttribute( 'font-size' );
+		var fontsize = getFontSize(svgdest);
 		var scale = 0.0016 * fontsize;
 		var x =  +svgdest.getAttribute( 'x' );
 		if ( svgdest.hasAttribute( 'dx' ) ) x = x + svgdest.getAttribute( 'dx' );


### PR DESCRIPTION
Solves #88 

When importing SVG files created by the python matplotlib library, latex labels are not depicted for the two following reasons:

- the variable "scale" cannot be evaluated since no "font-size" attribute is available
- possible rotation information of the labels are ignored

This pull request adresses these two issues. First of all, it provides the new function "getFontSize()", which tries to evaluate the font size and catches possible errors. Moreover, the original transformation information of the text label is kept (see line 130) that the rotation information is also available in the output svg.

I have to admitt that I am not the big javascript developer. If there is any concern about the code design, please give me feedback.