### PR TITLE
Add instructions to use npm as an alternative to bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ You can download the plugins into the ```bower_components``` folder using
 
 ```bower install reveal.js-plugins```
 
+or use npm to install the plugins into the ```node_modules```folder using
+ 
+```npm install  reveal.js-plugins```
+
 or manually copy this repository next to the folder of your reveal.js presentation.
 
 Please note that the [menu](https://github.com/denehyg/reveal.js-menu)-plugin is a submodule and has to be downloaded separately.


### PR DESCRIPTION
Hello @rajgoel, 
Thanks for the work on this plugin. I would love to use it via npm and I've seen that you've created [an npm package](https://www.npmjs.com/package/reveal.js-plugins). 

Could you maybe update this package to the latest version and include the updated instructions in this PR?

Best,
Dennis