### PR TITLE
Fix chalkEffect setting being ignored

### DIFF
--- a/chalkboard/plugin.js
+++ b/chalkboard/plugin.js
@@ -115,7 +115,7 @@ const initChalkboard = function(Reveal){
 
 		if ( config.boardmarkerWidth || config.penWidth ) boardmarkerWidth = config.boardmarkerWidth || config.penWidth;
 		if ( config.chalkWidth ) chalkWidth = config.chalkWidth;
-		if ( "chalkEffect" in config ) chalkEffect = ("chalkEffect" in config);
+		if ( "chalkEffect" in config ) chalkEffect = config.chalkEffect;
 		if ( config.rememberColor ) rememberColor = config.rememberColor;
 		if ( config.eraser ) eraser = config.eraser;
 		if ("boardmarkers" in config) boardmarkers = config.boardmarkers;


### PR DESCRIPTION
Hi there. Thank you very much for your work!
I just installed the chalkboard plugin and recognized that the `chalkEffect` setting does not have any....well...effect. I think there is a copy/paste error in the code which sets `chalkEffect` always to true.