### PR TITLE
Update Font Awesome instructions to v5

### DIFF
--- a/chalkboard/README.md
+++ b/chalkboard/README.md
@@ -32,8 +32,8 @@ Copy the file `plugin.js` and the  `img` directory into the plugin folder of you
 ```
 
 In order to include buttons for opening and closing the notes canvas or the chalkboard you should make sure that `font-awesome` is available. The easiest way is to include
-```
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
+```html
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.3/css/all.css">
 ```
 to the `head` section of you HTML-file.
 

--- a/chalkboard/README.md
+++ b/chalkboard/README.md
@@ -37,6 +37,11 @@ In order to include buttons for opening and closing the notes canvas or the chal
 ```
 to the `head` section of you HTML-file.
 
+Alternatively, if you're using this package via NPM, you can use the built-in font-awesome distribution like so:
+```html
+<link rel="stylesheet" href="node_modules/reveal.js-plugins/menu/font-awesome/css/all.css">
+```
+
 ## Usage
 
 ### Enable & disable


### PR DESCRIPTION
This package already uses icons such as `fa-pen-square` from Font Awesome v5 that are unavailable in v4 (where a similar icon was called `fa-pencil-square`). The demo also uses v5. This fixes the instructions to match.

I also added information about how to use the built-in Font Awesome v5 distribution in the NPM package, which is how the demo works.

Replaces #103.