### PR TITLE
Allow chalkboard plugin to run in strict mode

### DIFF
--- a/chalkboard/plugin.js
+++ b/chalkboard/plugin.js
@@ -16,7 +16,7 @@
 window.RevealChalkboard = window.RevealChalkboard || {
 	id: 'RevealChalkboard',
 	init: function ( deck ) {
-		initChalkboard( deck );
+		initChalkboard.call(this, deck );
 	},
 	configure: function ( config ) {
 		configure( config );

--- a/chalkboard/plugin.js
+++ b/chalkboard/plugin.js
@@ -90,7 +90,7 @@ const initChalkboard = function ( Reveal ) {
 /*****************************************************************
  ** Configuration
  ******************************************************************/
-	var background, pen, draw, color;
+	var background, pens, draw, color;
 	var grid = false;
 	var boardmarkerWidth = 3;
 	var chalkWidth = 7;


### PR DESCRIPTION
Making sure that the chalkboard plugin does not throw errors when javascript is running in strict mode (e.g. when using a bundler like Vite)