### PR TITLE
Handle case where controls are not defined or empty

### DIFF
--- a/customcontrols/plugin.js
+++ b/customcontrols/plugin.js
@@ -3,7 +3,7 @@
 **
 ** A plugin replacing the default controls by custom controls.
 **
-** Version: 2.0.0
+** Version: 2.0.1
 ** 
 ** License: MIT license (see LICENSE.md)
 **
@@ -17,6 +17,8 @@ window.RevealCustomControls = window.RevealCustomControls || {
 
 const initCustomControls = function(Reveal){
 	var config = Reveal.getConfig().customcontrols || {};
+
+	if (!config?.controls?.length) return this;
 
 	var collapseIcon = config.collapseIcon || '<i class="fa fa-chevron-down"></i>';
 	var expandIcon = config.expandIcon || '<i class="fa fa-chevron-up"></i>';


### PR DESCRIPTION
Currently, if you include the plugin without defining customs controls this break everything. This fix this issue (which shouldn't happend a lots, but it's always better to be able to temporary remove menu without breaking everythings).