### PR TITLE
Fix blur on overlay also for older Safari

### DIFF
--- a/chalkboard/plugin.js
+++ b/chalkboard/plugin.js
@@ -444,6 +444,7 @@ const initChalkboard = function ( Reveal ) {
 			container.style.visibility = 'visible';
 			container.style.pointerEvents = 'none';
 			container.style['backdrop-filter'] = 'none';
+			container.style['-webkit-backdrop-filter'] = 'none';
 
 			var slides = document.querySelector( '.slides' );
 			var aspectRatio = Reveal.getConfig().width / Reveal.getConfig().height;


### PR DESCRIPTION
This PR adds `-webkit-backdrop-filter` equivalent to `backdrop-filter` for Safari support to disable blur on overlay set by revealjs

This is a follow up on #180 to fix #179 also on older safari. `backdrop-filter` is baseline in browser only since september 2024 with safari 18. For older version the `-webkit` variant is required.

This was required to completely fix the chalkboard plugin when updating to Revealjs 5 in our project https://github.com/quarto-dev/quarto-cli/issues/10842

We'll patch our copy but I figured it would be good to have upstream

## Context for the change

- `backdrop-filter` support: https://caniuse.com/?search=backdrop-filter
- Revealjs adds the `-webkit` prefix where needed when building so the extension needs to opt out both rule so that it works in Safari too. 