### PR TITLE
Add r-overlay class to container

### DIFF
--- a/chalkboard/plugin.js
+++ b/chalkboard/plugin.js
@@ -424,6 +424,7 @@ const initChalkboard = function ( Reveal ) {
 		var container = document.createElement( 'div' );
 		container.id = drawingCanvas[ id ].id;
 		container.classList.add( 'overlay' );
+		container.classList.add( 'r-overlay' );
 		container.setAttribute( 'data-prevent-swipe', 'true' );
 		container.oncontextmenu = function () {
 			return false;


### PR DESCRIPTION
In the recent commit  (hakimel/reveal.js@fe67bad) of reveal.js, the class name of the container is changed to "r-overlay". This pull request adds the new class name to the created container in "chalkboard/plugin.js", so that the latest version of reveal.js will also be supported.